### PR TITLE
Fuzzer: detect undefined behaviours

### DIFF
--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -59,5 +59,5 @@ add_executable(fuzz_message
 )
 
 target_include_directories(fuzz_message PUBLIC ../src)
-target_compile_options(fuzz_message PUBLIC -fsanitize=fuzzer,address,undefined)
-target_link_options(fuzz_message PUBLIC -fsanitize=fuzzer,address,undefined)
+target_compile_options(fuzz_message PUBLIC -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined)
+target_link_options(fuzz_message PUBLIC -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined)

--- a/fuzzing/fuzz_neo3.c
+++ b/fuzzing/fuzz_neo3.c
@@ -5,7 +5,7 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     buffer_t buf = {.offset = 0, .ptr = Data, .size = Size};
-    transaction_t tx;
+    transaction_t tx = {0};
 
     transaction_deserialize(&buf, &tx);
     return 0;


### PR DESCRIPTION
Crash when an undefined behaviour is encountered during fuzzing.

Also, properly initialize transaction in fuzzing harness to avoid a boolean to take an undefined value.